### PR TITLE
add the possibility to pass BROKER_TRANSPORT_OPTIONS as env var

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,8 @@ ENV PYTHONPATH ${FLOWER_DATA_DIR}
 
 WORKDIR $FLOWER_DATA_DIR
 
+COPY conf/celeryconfig.py $FLOWER_DATA_DIR/celeryconfig.py
+
 # Add a user with an explicit UID/GID and create necessary directories
 RUN set -eux; \
     addgroup -g 1000 flower; \

--- a/conf/celeryconfig.py
+++ b/conf/celeryconfig.py
@@ -1,0 +1,4 @@
+import json
+import os
+
+BROKER_TRANSPORT_OPTIONS = json.loads(os.getenv('BROKER_TRANSPORT_OPTIONS', '{}'))


### PR DESCRIPTION
This PR adds the possibility to pass `BROKER_TRANSPORT_OPTIONS` config  as env var, which makes life easier when deploying to preview instances